### PR TITLE
Add support for a custom node visitor to override the default

### DIFF
--- a/src/GenerateStubsCommand.php
+++ b/src/GenerateStubsCommand.php
@@ -58,6 +58,7 @@ class GenerateStubsCommand extends Command
             ->addOption('out', null, InputOption::VALUE_REQUIRED, 'Path to a file to write pretty-printed stubs to.  If unset, stubs will be written to stdout.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Whether to force an overwrite.')
             ->addOption('finder', null, InputOption::VALUE_REQUIRED, 'Path to a PHP file which returns a `Symfony\Finder` instance including the set of files that should be parsed.  Can be used instead of, but not in addition to, passing sources directly.')
+            ->addOption('visitor', null, InputOption::VALUE_REQUIRED, 'Path to a PHP file which returns a `StubsGenerator\NodeVisitor` instance to replace the default node visitor.')
             ->addOption('header', null, InputOption::VALUE_REQUIRED, 'A doc comment to prepend to the top of the generated stubs file.  (Will be added below the opening `<?php` tag.)', '')
             ->addOption('nullify-globals', null, InputOption::VALUE_NONE, 'Initialize all global variables with a value of `null`, instead of their assigned value.')
             ->addOption('stats', null, InputOption::VALUE_NONE, 'Whether to print stats instead of outputting stubs.  Stats will always be printed if --out is provided.');
@@ -94,13 +95,30 @@ class GenerateStubsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
+        $visitor = null;
+        $visitorPath = $input->getOption('visitor');
+
+        if ($visitorPath) {
+            $visitorPath = $this->resolvePath($visitorPath);
+            if (!$this->filesystem->exists($visitorPath) || is_dir($visitorPath)) {
+                throw new InvalidArgumentException("Bad --visitor path: '$visitorPath' does not exist or is a directory.");
+            }
+            try {
+                $visitor = @include $visitorPath;
+            } catch (Exception $e) {
+                throw new RuntimeException("Could not resolve a `StubsGenerator\NodeVisitor` from '$visitorPath'.", 0, $e);
+            }
+            if (!$visitor || !($visitor instanceof NodeVisitor)) {
+                throw new RuntimeException("Could not resolve a `StubsGenerator\NodeVisitor` from '$visitorPath'.");
+            }
+        }
 
         $finder = $this->parseSources($input);
         $generator = new StubsGenerator($this->parseSymbols($input), [
             'nullify_globals' => $input->getOption('nullify-globals'),
         ]);
 
-        $result = $generator->generate($finder);
+        $result = $generator->generate($finder, $visitor);
 
         $printer = new Standard();
 

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -84,7 +84,7 @@ class NodeVisitor extends NodeVisitorAbstract
     /**
      * @param int $symbols Set of symbol types to include stubs for.
      */
-    public function __construct(int $symbols = StubsGenerator::DEFAULT, array $config = [])
+    public function init(int $symbols = StubsGenerator::DEFAULT, array $config = [])
     {
         $this->needsFunctions = ($symbols & StubsGenerator::FUNCTIONS) !== 0;
         $this->needsClasses = ($symbols & StubsGenerator::CLASSES) !== 0;

--- a/src/StubsGenerator.php
+++ b/src/StubsGenerator.php
@@ -99,15 +99,21 @@ class StubsGenerator
      * pretty-printed stubs.
      *
      * @param Finder $finder The set of files to generate (merged) stubs for.
+     * @param NodeVisitor $visitor The optional node visitor to override the default.
      *
      * @return Result
      */
-    public function generate(Finder $finder): Result
+    public function generate(Finder $finder, NodeVisitor $visitor = null): Result
     {
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
 
+        if (!($visitor instanceof NodeVisitor)) {
+            $visitor = new NodeVisitor;
+        }
+
+        $visitor->init($this->symbols, $this->config);
+
         $traverser = new NodeTraverser();
-        $visitor = new NodeVisitor($this->symbols, $this->config);
         $traverser->addVisitor(new NameResolver());
         $traverser->addVisitor($visitor);
 


### PR DESCRIPTION
This adds a `--visitor=<file>` flag which works much like the `--finder=<file>` flag and allows a custom node visitor instance to be provided. This allows for custom pre- or post-processing of nodes, in particular their docblock.